### PR TITLE
removes obsolete conditional

### DIFF
--- a/lib/locale_setter/generic.rb
+++ b/lib/locale_setter/generic.rb
@@ -16,7 +16,7 @@ module LocaleSetter
     end
 
     def self.from_user(user, available)
-      LocaleSetter::User.for(user, available) if user
+      LocaleSetter::User.for(user, available)
     end
 
     def self.from_http(env, available)


### PR DESCRIPTION
`LocaleSetter::User.for` starts checking if user is not false:

``` ruby
if user && user.respond_to?(locale_method) &&
```
