### PR TITLE
subdomains now working

### DIFF
--- a/lib/locale_setter/controller.rb
+++ b/lib/locale_setter/controller.rb
@@ -17,7 +17,7 @@ module LocaleSetter
         i18n,
         {:params => params,
          :user   => locale_user,
-         :domain => request.domain,
+         :domain => request.host,
          :env    => request.env}
       )
     end


### PR DESCRIPTION
You were only sending request.domain which does not include the subdomain
I changed this to request.host which includes the subdomain.
Now works as expected
