### PR TITLE
Railtie now sends to ActionController::Base instead of ApplicationController directly

### DIFF
--- a/lib/locale_setter/railtie.rb
+++ b/lib/locale_setter/railtie.rb
@@ -6,7 +6,7 @@ module LocaleSetter
       # I would prefer to do this in an initializer block, but it's important
       # that we do this _before_ any of the user's authentication stuff
       # happens. So this is the best we can get for now.
-      ApplicationController.send(:include, LocaleSetter::Controller)
+      ActionController::Base.send(:include, LocaleSetter::Controller)
     end
   end
   module Rails

--- a/lib/locale_setter/version.rb
+++ b/lib/locale_setter/version.rb
@@ -1,3 +1,3 @@
 module LocaleSetter
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
No longer prescribes the name of application controller. Permits the use of custom name (+spaced) application controllers.
